### PR TITLE
Fix for: Timeout Error: waiting for locator("[data-test-id=\"post-content\"]")

### DIFF
--- a/Graphics/screenshot.py
+++ b/Graphics/screenshot.py
@@ -1,5 +1,6 @@
 import json
 import re
+import config
 from pathlib import Path
 from typing import Dict, Final
 
@@ -26,6 +27,7 @@ def get_screenshots_of_reddit_posts(reddit_thread, reddit_comments, screenshot_n
 
         browser = p.chromium.launch(headless=True)  # headless=False #to check for chrome view
         context = browser.new_context()
+        my_config = config.load_config()
         # Device scale factor (or dsf for short) allows us to increase the resolution of the screenshots
         # When the dsf is 1, the width of the screenshot is 600 pixels
         # So we need a dsf such that the width of the screenshot is greater than the final resolution of the video
@@ -53,11 +55,24 @@ def get_screenshots_of_reddit_posts(reddit_thread, reddit_comments, screenshot_n
 
         # Get the thread screenshot
         page = context.new_page()
+        # go to reddit's login page
+        page.goto("https://www.reddit.com/login/?experiment_d2x_2020ify_buttons=enabled&use_accountmanager=true&experiment_d2x_google_sso_gis_parity=enabled&experiment_d2x_onboarding=enabled&experiment_d2x_am_modal_design_update=enabled")
+        # fill user info
+        page.locator("id=loginUsername").fill(my_config["RedditCredential"]["username"])
+        page.locator("id=loginPassword").fill(my_config["RedditCredential"]["passkey"])
+        page.get_by_role("button", name="Log In").click()
+        time.sleep(10)
+        # go to the thread
+        page.goto("https://www.reddit.com" + reddit_thread.permalink, timeout=0)
+        time.sleep(10)
+        page.keyboard.press("Escape")
+        
         page.goto("https://www.reddit.com" + reddit_thread.permalink, timeout=0)
         page.set_viewport_size(ViewportSize(width=W, height=H))
 
         postcontentpath = f"./Assets/temp/{reddit_id}/png/title.png"
         page.locator(f'[data-test-id="post-content"]').screenshot(path=postcontentpath)
+        print("Screenshot for OP completed")
 
 
 
@@ -73,6 +88,7 @@ def get_screenshots_of_reddit_posts(reddit_thread, reddit_comments, screenshot_n
                 page.locator(f"#t1_{comment.id}").screenshot(
                     path=f"./Assets/temp/{reddit_id}/png/{idx}.png"
                 )
+                print(f"Screenshot for {idx + 1} comment out of {len(reddit_comments)}")
             except TimeoutError:
                 print("TimeoutError: Skipping screenshot...")
                 continue


### PR DESCRIPTION
The problem is when playwright opens the browser and there is no user logged in, this changes the structure of the site and prevents playwright from finding the mentioned selector.
My fix uses the credentials entered in the config file and opens the login page, uses the user credentials to log in, wait to be redirected back to the main site and only then navigate to the thread.

I also added some print lines to give more visibility to the app progress. 